### PR TITLE
Added new function git-object-free

### DIFF
--- a/cl-git.lisp
+++ b/cl-git.lisp
@@ -113,6 +113,10 @@
     :void
   (object :pointer))
 
+(cffi:defcfun ("git_object_free" %git-object-free)
+    :void
+  (object :pointer))
+
 ;;; Git Commit
 (cffi:defcfun ("git_commit_create" %git-commit-create)
     :int
@@ -421,7 +425,7 @@ manually with GIT-TREE-CLOSE."
 
 (defun git-tree-close (tree)
   "Close the tree and free the memory allocated to the tree."
-  (%git-object-close tree))
+  (%git-object-free tree))
 
 (defun git-commit-lookup (oid)
   "Look up a commit by oid, return the resulting commit.  This commit
@@ -455,7 +459,7 @@ will need to be freed manually with GIT-COMMIT-CLOSE."
 
 (defun git-commit-close (commit)
   "Close the commit and free the memory allocated to the commit."
-  (%git-object-close commit))
+  (%git-object-free commit))
 
 (defun git-oid-fromstr (str)
   "Convert a Git hash to an oid."


### PR DESCRIPTION
Added new function git-object-free because it seems that git_object_close does not exist in newer versions of libgit2.  Note that this change is not backward compatible, it unconditionally replaces calls of git-object-close with git-object-free.

I am not very experienced with cffi so I do not know how to check which of the two version is defined
so it will be transparent for the user.
Also I have not removed git-object-close so this is at the moment dead code.

I just made this pull request to play with pull request, so do whatever you want with it :-)
