### PR TITLE
Added a few functions to examine the config and git-tree objects

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -45,6 +45,7 @@
    #:git-tree-close
    #:git-tree-entries
    #:git-object-lookup
+   #:git-object-id
    #:git-object-type
    #:git-object-free
    #:git-blob-raw-size


### PR DESCRIPTION
Most of the changes in these commits are harmless.  
However there is one change that might break old code and that is, I changed
the type of size_t from unsigned int --> unsigned long.
The reason is that for me on MacOSX (64-bit) the size_t is a long.
However I do not know how this works on different platforms.

Unfortunately I do not know how to figure out what the size of a size_t is in lisp.

If it does not work for you, you can change it back and I will see if I can find a workaround.

Wim Oudshoorn
