### PR TITLE
Add #:flexi-streams to cl-git.asd

### DIFF
--- a/cl-git.asd
+++ b/cl-git.asd
@@ -8,7 +8,7 @@
   :version (:read-file-form "version.lisp-expr")
   :serial t
   :defsystem-depends-on (:asdf)
-  :depends-on (#:cffi #:local-time #:cl-fad #:trivial-garbage #:anaphora #:alexandria #:closer-mop)
+  :depends-on (#:cffi #:local-time #:cl-fad #:flexi-streams #:trivial-garbage #:anaphora #:alexandria #:closer-mop)
   :author "Russell Sim <russell.sim@gmail.com>"
   :licence "Lisp-LGPL"
   :components ((:static-file "cl-git.asd")


### PR DESCRIPTION
Miss #:flexi-streams will lead to an error "The name "FLEXI-STREAMS" does not designate any package".

Thanks for developing the remote functions! It's my honor to test it.
