### PR TITLE
Fixes for libgit2 v0.24.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,18 @@ language: lisp
 env:
   matrix:
     # - LISP=abcl
-    - LISP=sbcl LIBGIT2_VERSION=0.21.1
-    - LISP=sbcl LIBGIT2_VERSION=0.21.2
-    - LISP=sbcl LIBGIT2_VERSION=0.21.3
-    - LISP=ccl LIBGIT2_VERSION=0.21.3
+    - LISP=sbcl LIBGIT2_VERSION=0.26.0
+    - LISP=ccl LIBGIT2_VERSION=0.26.0
     # - LISP=ccl32
-    - LISP=clisp LIBGIT2_VERSION=0.21.3
+    - LISP=clisp LIBGIT2_VERSION=0.26.0
     # - LISP=clisp32
     # - LISP=cmucl
-    - LISP=ecl LIBGIT2_VERSION=0.21.3
+    - LISP=ecl LIBGIT2_VERSION=0.26.0
 
 matrix:
  allow_failures:
-   - env: LISP=clisp LIBGIT2_VERSION=0.21.3
-   - env: LISP=ecl LIBGIT2_VERSION=0.21.3
+   - env: LISP=clisp LIBGIT2_VERSION=0.26.0
+   - env: LISP=ecl LIBGIT2_VERSION=0.26.0
 
 before_install:
  - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
  - mkdir libgit-build
  - pushd libgit-build && cmake -DCMAKE_VERBOSE_MAKEFILE=ON ../libgit2-${LIBGIT2_VERSION} && popd
  - pushd libgit-build && cmake --build . && popd
- - pushd libgit-build && sudo cmake --build . --target install && popd
+ - pushd libgit-build && cmake --build . --target install && popd
 
 install:
   - if [ -x ./install.sh ] && head -2 ./install.sh | grep '^#cl-travis' > /dev/null;

--- a/src/libgit2.lisp
+++ b/src/libgit2.lisp
@@ -58,17 +58,17 @@ list return values are :THREADS and :HTTPS.")
   (minor :pointer)
   (revision :pointer))
 
-(defcfun ("git_threads_init" git-threads-init)
+(defcfun ("git_libgit2_init" git-init)
     :void
-    "Init libgit2 threading.")
+    "Init libgit2.")
 
-(defcfun ("git_threads_shutdown" git-threads-shutdown)
+(defcfun ("git_libgit2_shutdown" git-shutdown)
     :void
-    "Shutdown libgit2 threading.")
+    "Shutdown libgit2.")
 
 ;;; Init threading on load
 (eval-when (:load-toplevel :execute)
-  (git-threads-init))
+  (git-init))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/libgit2.lisp
+++ b/src/libgit2.lisp
@@ -32,7 +32,7 @@
 (define-foreign-library libgit2
   (:linux "libgit2.so.21")
   (:windows "libgit2.dll")
-  (:darwin "libgit2.0.dylib")
+  (:darwin "libgit2.dylib")
   (:default "libgit2"))
 
 (unless (foreign-library-loaded-p 'libgit2)


### PR DESCRIPTION
I was unable to run cl-git on OS X and noticed that the current version is slightly incompatible with libgit2 v0.24.0. These two commits fix that.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/russell/cl-git/32)

<!-- Reviewable:end -->
