### PR TITLE
Fix typo in documentation of make-commit function

### DIFF
--- a/src/commit.lisp
+++ b/src/commit.lisp
@@ -101,7 +101,7 @@ of parents of the commit `commit'."
   "Create a new commit from the tree with the OID specified and
 MESSAGE.  Optional :UPDATE-REF is the name of the reference that will
 be updated to point to this commit.  The default value \"HEAD\" will
-updote the head of the current branch.  If it's value is NULL then no
+update the head of the current branch.  If it's value is NULL then no
 reference will be updated.  :AUTHOR is an optional instance of a
 GIT-SIGNATURE that details the commit author.  :COMMITTER is an
 optional instance of a GIT-SIGNATURE the details the committer.


### PR DESCRIPTION
I noticed this little typo while reading the docs.
Thanks for your work. I'm excited to play around with this.