### PR TITLE
Backwards compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,35 +3,19 @@ name: CI
 
 'on': [push]
 
-env:
-  LIBGIT2_VERSION: 1.3.2
-
 jobs:
   test:
-    name: ${{ matrix.lisp }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.lisp }} with libgit2 ${{ matrix.libgit2 }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         lisp: [sbcl-bin]
-        os: [ubuntu-latest]
-
+        libgit2: ['0.27', '0.28', '1.0', '1.1', '1.2', '1.3', '1.4', '1.5']
     steps:
-      - uses: actions/checkout@v1
-      - name: Install libgit2
-        run: |
-          wget --progress=dot https://github.com/libgit2/libgit2/archive/v${LIBGIT2_VERSION}.tar.gz
-          tar -zxf v${LIBGIT2_VERSION}.tar.gz
-          mkdir libgit-build
-          cd libgit-build
-          cmake -DCMAKE_VERBOSE_MAKEFILE=ON ../libgit2-${LIBGIT2_VERSION}
-          cmake --build .
-          sudo cmake --build . --target install
-      - name: Install Roswell
+      - uses: earthly/actions-setup@v1
+        with:
+          version: "latest"
+      - name: Test
         env:
-          LISP: ${{ matrix.lisp }}
-        run: |
-          curl -L https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh | sh
-      - name: Run Tests
-        env:
-          LD_LIBRARY_PATH: /usr/local/lib
-        run: ./run-tests.lisp
+          LIBGIT2: ${{ matrix.libgit2 }}
+        run: earthly github.com/russell/cl-git:$GITHUB_SHA+test-libgit2-$LIBGIT2

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,63 @@
+VERSION 0.6
+FROM debian:stable
+WORKDIR /cl-git
+ENV ROSWELL_DIST=https://raw.githubusercontent.com/roswell/roswell/master/scripts/install-for-ci.sh
+
+deps:
+    ENV LISP=sbcl-bin
+    ENV CI=true
+    ENV PATH="~/.roswell/bin:$PATH"
+    RUN apt-get update && apt-get install -y curl make bzip2 libcurl3-gnutls zlib1g-dev lsof
+    RUN curl -L $ROSWELL_DIST | sh
+
+build:
+    FROM +deps
+    FROM +libgit2
+    COPY cl-git.asd version.lisp-expr run-tests.lisp ./src/ ./tests/ /root/.roswell/local-projects/cl-git/
+    COPY src /root/.roswell/local-projects/cl-git/src
+    COPY tests /root/.roswell/local-projects/cl-git/tests
+    # TODO Testing build here doesn't work reliably, ros always tries
+    # to return success, and asdf can never find the cffi-grovel
+    # extensions...
+    # RUN ros run -v -e  "(handler-case (asdf:oos 'asdf:test-op :cl-git) (simple-error (e) (format t \"~A\" e) (uiop:quit 1)))"
+
+libgit2:
+    FROM +deps
+    ARG --required LIBGIT2_VERSION
+    RUN apt-get update && apt-get install -y cmake gcc libssl-dev libcurl4-gnutls-dev libssh2-1-dev
+    RUN curl -L https://github.com/libgit2/libgit2/archive/v${LIBGIT2_VERSION}.tar.gz > v${LIBGIT2_VERSION}.tar.gz
+    RUN tar -zxf v${LIBGIT2_VERSION}.tar.gz
+    RUN mkdir libgit-build
+    RUN cd libgit-build && \
+        cmake -DBUILD_TESTS=OFF -DBUILD_CLAR=OFF -DCMAKE_VERBOSE_MAKEFILE=ON ../libgit2-${LIBGIT2_VERSION} && \
+        cmake --build . && \
+        cmake --build . --target install
+    RUN ldconfig
+
+test-libgit2:
+    FROM +build
+    RUN /root/.roswell/local-projects/cl-git/run-tests.lisp
+
+test-libgit2-0.27:
+    FROM +test-libgit2 --LIBGIT2_VERSION=0.27.10
+
+test-libgit2-0.28:
+    FROM +test-libgit2 --LIBGIT2_VERSION=0.28.5
+
+test-libgit2-1.0:
+    FROM +test-libgit2 --LIBGIT2_VERSION=1.0.1
+
+test-libgit2-1.1:
+    FROM +test-libgit2 --LIBGIT2_VERSION=1.1.1
+
+test-libgit2-1.2:
+    FROM +test-libgit2 --LIBGIT2_VERSION=1.2.0
+
+test-libgit2-1.3:
+    FROM +test-libgit2 --LIBGIT2_VERSION=1.3.2
+
+test-libgit2-1.4:
+    FROM +test-libgit2 --LIBGIT2_VERSION=1.4.4
+
+test-libgit2-1.5:
+    FROM +test-libgit2 --LIBGIT2_VERSION=1.5.0

--- a/README.org
+++ b/README.org
@@ -19,7 +19,7 @@ enough for this library to be useful.
 * Requires
 
 - SBCL 1.2.6 x86-64 or CCL 1.10 x86-64
-- libgit2: 1.3
+- libgit2: 0.27, 0.28, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5
 
 * Testing
 

--- a/cl-git.asd
+++ b/cl-git.asd
@@ -28,18 +28,27 @@
   ((:file "package")
    (:file "git-pointer"
     :depends-on ("package"))
-   (cffi-grovel:grovel-file "libgit2-types-grovel0"
-                            :depends-on ("package"))
-   (cffi-grovel:grovel-file "libgit2-types-grovel1"
-                            :depends-on ("libgit2-types"
-                                         "libgit2-types-grovel0"
-                                         "package"))
+   (:file "libgit2" :depends-on ("package"
+                                 "libgit2-lib"
+                                 "libgit2-types"
+                                 "libgit2-types-grovel1"))
+   (:file "libgit2-lib" :depends-on ("package"))
    (:file "libgit2-types" :depends-on ("package"
                                        "git-pointer"
+                                       "libgit2-features"
                                        "libgit2-types-grovel0"))
+   (:file "libgit2-features" :depends-on ("package"
+                                          "libgit2-lib"))
+   (cffi-grovel:grovel-file "libgit2-types-grovel0"
+                            :depends-on ("package"
+                                         "libgit2-features"
+                                         "libgit2-lib"))
+   (cffi-grovel:grovel-file "libgit2-types-grovel1"
+                            :depends-on ("package"
+                                         "libgit2-features"
+                                         "libgit2-types"
+                                         "libgit2-types-grovel0"))
    (:file "api" :depends-on ("package"))
-   (:file "libgit2" :depends-on ("package" "libgit2-types"
-                                           "libgit2-types-grovel1"))
    (:file "buffer" :depends-on ("libgit2"))
    (:file "error" :depends-on ("libgit2"))
    (:file "strarray" :depends-on ("libgit2"))

--- a/src/diff.lisp
+++ b/src/diff.lisp
@@ -79,7 +79,14 @@
   (:actual-type :pointer)
   (:simple-parser %diff-list))
 
+#-(or libgit2-0.28 libgit2-0.27)
 (defcfun %git-diff-options-init
+    %return-value
+  (options :pointer)
+  (version :unsigned-int))
+
+#+(or libgit2-0.28 libgit2-0.27)
+(defcfun ("git_diff_init_options" %git-diff-options-init)
     %return-value
   (options :pointer)
   (version :unsigned-int))

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -142,7 +142,9 @@
 (define-git-condition stop-iteration :iterover)
 (define-git-condition retry :retry)
 (define-git-condition mismatch-error :emismatch)
+#-libgit2-0.27
 (define-git-condition index-dirty-error :eindexdirty)
+#-libgit2-0.27
 (define-git-condition apply-fail-error :eapplyfail)
 
 (define-condition unknown-error (basic-error) ()

--- a/src/libgit2-features.lisp
+++ b/src/libgit2-features.lisp
@@ -2,7 +2,6 @@
 
 ;; cl-git is a Common Lisp interface to git repositories.
 ;; Copyright (C) 2011-2022 Russell Sim <russell.sim@gmail.com>
-;; Copyright (C) 2012 Willem Rein Oudshoorn <woudshoo@xs4all.nl>
 ;;
 ;; This program is free software: you can redistribute it and/or
 ;; modify it under the terms of the GNU Lesser General Public License
@@ -21,14 +20,7 @@
 
 (in-package #:cl-git)
 
-(defcfun ("git_libgit2_init" git-libgit2-init)
-    :void
-  "Init libgit2.")
-
-(defcfun ("git_libgit2_shutdown" git-libgit2-shutdown)
-    :void
-  "Shutdown libgit2.")
-
-;;; Init threading on load
-(eval-when (:load-toplevel :execute)
-  (git-libgit2-init))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (pushnew (intern (apply 'format nil "LIBGIT2-~a.~a" (libgit2-version))
+                   (find-package 'keyword))
+           *features*))

--- a/src/libgit2-lib.lisp
+++ b/src/libgit2-lib.lisp
@@ -1,0 +1,71 @@
+;;; -*- Mode: Lisp; Syntax: COMMON-LISP; Base: 10 -*-
+
+;; cl-git is a Common Lisp interface to git repositories.
+;; Copyright (C) 2011-2022 Russell Sim <russell.sim@gmail.com>
+;; Copyright (C) 2012 Willem Rein Oudshoorn <woudshoo@xs4all.nl>
+;;
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU Lesser General Public License
+;; as published by the Free Software Foundation, either version 3 of
+;; the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; Lesser General Public License for more details.
+;;
+;; You should have received a copy of the GNU Lesser General Public
+;; License along with this program.  If not, see
+;; <http://www.gnu.org/licenses/>.
+
+
+(in-package #:cl-git)
+
+(define-foreign-library libgit2
+  (:linux "libgit2.so")
+  (:windows "libgit2.dll")
+  (:darwin "libgit2.0.dylib")
+  (:default "libgit2"))
+
+(unless (foreign-library-loaded-p 'libgit2)
+  (use-foreign-library libgit2))
+
+(defbitfield git-capabilities
+  (:threads 1)
+  (:https 2)
+  (:ssh 4)
+  (:nsec 8))
+
+(defcfun ("git_libgit2_features" libgit2-features)
+    git-capabilities
+  "Return a list of the libgit2 capabilities, possible values in the
+list return values are :THREADS and :HTTPS.")
+
+(defcfun ("git_libgit2_version" %git-version)
+    :void
+  (major :pointer)
+  (minor :pointer)
+  (revision :pointer))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+(defun libgit2-version ()
+  "Returns the libgit2 C-library version number as a list of three integers,
+\(major minor revision\)."
+  (with-foreign-objects
+      ((maj :int)
+       (min :int)
+       (rev :int))
+    (%git-version maj min rev)
+    (list (mem-ref maj :int)
+          (mem-ref min :int)
+          (mem-ref rev :int))))
+
+(defmethod translate-name-to-foreign ((lisp-name symbol)
+                                      (package (eql *package*))
+                                      &optional varp)
+  (let ((name (translate-underscore-separated-name lisp-name)))
+    (if varp
+        (string-trim '(#\* #\%) name)
+        (string-trim '(#\%) name))))

--- a/src/libgit2-types-grovel0.lisp
+++ b/src/libgit2-types-grovel0.lisp
@@ -66,6 +66,7 @@
        ((:conflict-style-diff3 "GIT_CHECKOUT_CONFLICT_STYLE_DIFF3"))
        ((:dont-remove-existing "GIT_CHECKOUT_DONT_REMOVE_EXISTING"))
        ((:dont-write-index "GIT_CHECKOUT_DONT_WRITE_INDEX"))
+       #-(or libgit2-1.1 libgit2-1.0 libgit2-0.28 libgit2-0.27)
        ((:dry-run "GIT_CHECKOUT_DRY_RUN"))
 
        ;; Not implemented yet in libgit2
@@ -158,6 +159,7 @@ without this flag, diff will always leave the index untouched.")
         :documentation "Use a heuristic that takes indentation and whitespace into account
 which generally can produce better diffs when dealing with ambiguous
 diff hunks.")
+       #-(or libgit2-1.1 libgit2-1.0 libgit2-0.28 libgit2-0.27)
        ((:ignore-blank-lines "GIT_DIFF_IGNORE_BLANK_LINES")
         :documentation "Ignore blank lines")
        ((:force-text "GIT_DIFF_FORCE_TEXT")
@@ -204,6 +206,17 @@ can apply given diff information to binary files."))
 ;; Credential
 ;;
 
+#+(or libgit2-0.28 libgit2-0.27)
+(cenum git-credential-t
+       ((:userpass-plaintext "GIT_CREDTYPE_USERPASS_PLAINTEXT"))
+       ((:ssh-key "GIT_CREDTYPE_SSH_KEY"))
+       ((:ssh-custom "GIT_CREDTYPE_SSH_CUSTOM"))
+       ((:default "GIT_CREDTYPE_DEFAULT"))
+       ((:ssh-interactive "GIT_CREDTYPE_SSH_INTERACTIVE"))
+       ((:username "GIT_CREDTYPE_USERNAME"))
+       ((:ssh-memory "GIT_CREDTYPE_SSH_MEMORY")))
+
+#-(or libgit2-0.28 libgit2-0.27)
 (cenum git-credential-t
        ((:userpass-plaintext "GIT_CREDENTIAL_USERPASS_PLAINTEXT")
         :documentation

--- a/src/libgit2-types-grovel1.lisp
+++ b/src/libgit2-types-grovel1.lisp
@@ -45,9 +45,13 @@
 (ctype git-time-t "git_time_t")
 
 ;; The maximum size of an object
+#+(or libgit2-0.28 libgit2-0.27)
+(ctype object-size-t "git_off_t")
+#-(or libgit2-0.28 libgit2-0.27)
 (ctype object-size-t "git_object_size_t")
 
 
+#-libgit2-0.27
 (cenum git-object-t
        ((:any "GIT_OBJECT_ANY")
         :documentation "Object can be any of the following")
@@ -66,6 +70,25 @@
        ((:ref-delta "GIT_OBJECT_REF_DELTA")
         :documentation "A delta, base is given by object id."))
 
+#+libgit2-0.27
+(cenum git-object-t
+       ((:any "GIT_OBJ_ANY")
+        :documentation "Object can be any of the following")
+       ((:invalid "GIT_OBJ_BAD")
+        :documentation "Object is invalid.")
+       ((:commit "GIT_OBJ_COMMIT")
+        :documentation "A commit object.")
+       ((:tree "GIT_OBJ_TREE")
+        :documentation "A tree (directory listing) object.")
+       ((:blob "GIT_OBJ_BLOB")
+        :documentation "A file revision object.")
+       ((:tag "GIT_OBJ_TAG")
+        :documentation "An annotated tag object.")
+       ((:ofs-delta "GIT_OBJ_OFS_DELTA")
+        :documentation "A delta, base is given by an offset.")
+       ((:ref-delta "GIT_OBJ_REF_DELTA")
+        :documentation "A delta, base is given by object id."))
+
 (cstruct git-time "git_time"
          (time "time" :type %time-t)
          (offset "offset" :type :int)
@@ -76,6 +99,7 @@
          (email "email" :type :string)
          (when "when" :type (:struct git-time)))
 
+#-libgit2-0.27
 (cenum git-reference-t
        ((:invalid "GIT_REFERENCE_INVALID")
         :documentation "Invalid reference")
@@ -84,6 +108,17 @@
        ((:symbolic "GIT_REFERENCE_SYMBOLIC")
         :documentation "A reference that points at another reference")
        ((:all "GIT_REFERENCE_ALL")
+        :documentation "Either direct or symbolic"))
+
+#+libgit2-0.27
+(cenum git-reference-t
+       ((:invalid "GIT_REF_INVALID")
+        :documentation "Invalid reference")
+       ((:direct "GIT_REF_OID")
+        :documentation "A reference that points at an object id")
+       ((:symbolic "GIT_REF_SYMBOLIC")
+        :documentation "A reference that points at another reference")
+       ((:all "GIT_REF_LISTALL")
         :documentation "Either direct or symbolic"))
 
 (cenum git-branch-t
@@ -159,16 +194,33 @@
          (path "path" :type :string))
 
 ;; Bitmasks for on-disk fields of `git_index_entry`'s `flags`
+#-libgit2-0.27
 (constant (+git-index-entry-namemask+ "GIT_INDEX_ENTRY_NAMEMASK") :type integer)
+#-libgit2-0.27
 (constant (+git-index-entry-stagemask+ "GIT_INDEX_ENTRY_STAGEMASK") :type integer)
+#-libgit2-0.27
 (constant (+git-index-entry-stageshift+ "GIT_INDEX_ENTRY_STAGESHIFT") :type integer)
 
+#+libgit2-0.27
+(constant (+git-index-entry-namemask+ "GIT_IDXENTRY_NAMEMASK") :type integer)
+#+libgit2-0.27
+(constant (+git-index-entry-stagemask+ "GIT_IDXENTRY_STAGEMASK") :type integer)
+#+libgit2-0.27
+(constant (+git-index-entry-stageshift+ "GIT_IDXENTRY_STAGESHIFT") :type integer)
+
+#-libgit2-0.27
 (cenum git-index-capabilities-t
        ((:ignore-case "GIT_INDEX_CAPABILITY_IGNORE_CASE"))
        ((:no-filemode "GIT_INDEX_CAPABILITY_NO_FILEMODE"))
        ((:no-symlinks "GIT_INDEX_CAPABILITY_NO_SYMLINKS"))
        ((:from-owner "GIT_INDEX_CAPABILITY_FROM_OWNER")))
 
+#+libgit2-0.27
+(cenum git-index-capabilities-t
+       ((:ignore-case "GIT_INDEXCAP_IGNORE_CASE"))
+       ((:no-filemode "GIT_INDEXCAP_NO_FILEMODE"))
+       ((:no-symlinks "GIT_INDEXCAP_NO_SYMLINKS"))
+       ((:from-owner "GIT_INDEXCAP_FROM_OWNER")))
 
 
 ;;
@@ -216,8 +268,10 @@
          (push-update-reference-cb "push_update_reference" :type :pointer)
          (push-negotiation-cb "push_negotiation" :type :pointer)
          (transport-cb "transport" :type :pointer)
+         #-(or libgit2-1.1 libgit2-1.0 libgit2-0.28 libgit2-0.27)
          (remote-ready-cb "remote_ready" :type :pointer)
          (payload "payload" :type :pointer)
+         #-(or libgit2-0.28 libgit2-0.27)
          (resolve-url-cb "resolve_url" :type :pointer))
 
 (cenum (git-fetch-prune)
@@ -388,6 +442,8 @@ fetch for file:// URLs.")
 ;;
 ;; Indexer
 ;;
+
+#-(or libgit2-0.28 libgit2-0.27)
 (cstruct git-indexer-progress "git_indexer_progress"
          (total-objects "total_objects" :type :uint)
          (indexed-objects "indexed_objects" :type :uint)
@@ -410,7 +466,10 @@ fetch for file:// URLs.")
 ;;
 (cstruct git-buf "git_buf"
          (ptr "ptr" :type :pointer)
+         #-(or libgit2-1.4 libgit2-1.5)
          (asize "asize" :type size-t)
+         #+(or libgit2-1.4 libgit2-1.5)
+         (asize "reserved" :type size-t)
          (size "size" :type size-t))
 
 
@@ -449,6 +508,7 @@ specific config file available that actually is loaded)"))
 (cstruct git-config-entry "git_config_entry"
          (:name "name" :type :string)
          (:value "value" :type :string)
+         #-(or libgit2-0.28 libgit2-0.27)
          (:include-depth "include_depth" :type :uint)
          (:level "level" :type git-config-level-t)
          ;; XXX This will leak, it needs to free the method using a
@@ -461,6 +521,7 @@ specific config file available that actually is loaded)"))
 ;; Error
 ;;
 
+#-libgit2-0.27
 (cenum git-error-t
        ((:none "GIT_ERROR_NONE"))
        ((:nomemory "GIT_ERROR_NOMEMORY"))
@@ -496,8 +557,47 @@ specific config file available that actually is loaded)"))
        ((:patch "GIT_ERROR_PATCH"))
        ((:worktree "GIT_ERROR_WORKTREE"))
        ((:sha1 "GIT_ERROR_SHA1"))
+       #-libgit2-0.28
        ((:http "GIT_ERROR_HTTP"))
+       #-(or libgit2-1.0 libgit2-0.28)
        ((:internal "GIT_ERROR_INTERNAL")))
+
+#+libgit2-0.27
+(cenum git-error-t
+       ((:none "GITERR_NONE"))
+       ((:nomemory "GITERR_NOMEMORY"))
+       ((:os "GITERR_OS"))
+       ((:invalid "GITERR_INVALID"))
+       ((:reference "GITERR_REFERENCE"))
+       ((:zlib "GITERR_ZLIB"))
+       ((:repository "GITERR_REPOSITORY"))
+       ((:config "GITERR_CONFIG"))
+       ((:regex "GITERR_REGEX"))
+       ((:odb "GITERR_ODB"))
+       ((:index "GITERR_INDEX"))
+       ((:object "GITERR_OBJECT"))
+       ((:net "GITERR_NET"))
+       ((:tag "GITERR_TAG"))
+       ((:tree "GITERR_TREE"))
+       ((:indexer "GITERR_INDEXER"))
+       ((:ssl "GITERR_SSL"))
+       ((:submodule "GITERR_SUBMODULE"))
+       ((:thread "GITERR_THREAD"))
+       ((:stash "GITERR_STASH"))
+       ((:checkout "GITERR_CHECKOUT"))
+       ((:fetchhead "GITERR_FETCHHEAD"))
+       ((:merge "GITERR_MERGE"))
+       ((:ssh "GITERR_SSH"))
+       ((:filter "GITERR_FILTER"))
+       ((:revert "GITERR_REVERT"))
+       ((:callback "GITERR_CALLBACK"))
+       ((:cherrypick "GITERR_CHERRYPICK"))
+       ((:describe "GITERR_DESCRIBE"))
+       ((:rebase "GITERR_REBASE"))
+       ((:filesystem "GITERR_FILESYSTEM"))
+       ((:patch "GITERR_PATCH"))
+       ((:worktree "GITERR_WORKTREE"))
+       ((:sha1 "GITERR_SHA1")))
 
 (cenum git-error-code
        ((:ok "GIT_OK")
@@ -564,10 +664,12 @@ know that it was generated by the callback and not by libgit2.")
         :documentation "Internal only")
        ((:emismatch "GIT_EMISMATCH")
         :documentation "Hashsum mismatch in object")
+       #-libgit2-0.27
        ((:eindexdirty "GIT_EINDEXDIRTY")
         :documentation "Unsaved changes in the index would be overwritten")
+       #-libgit2-0.27
        ((:eapplyfail "GIT_EAPPLYFAIL")
-        :documentation "Patch application failed")
+        :documentation "Patch application failedq")
        ;; ((:eowner "GIT_EOWNER")
        ;;  :documentation "The object is not owned by the current user")
        )

--- a/src/libgit2-types.lisp
+++ b/src/libgit2-types.lisp
@@ -20,6 +20,9 @@
 
 (in-package #:cl-git)
 
+(defvar +success+ 0
+  "Used to signal success for C return values in callbacks.")
+
 (define-foreign-type time-t ()
   nil
   (:actual-type git-time-t)

--- a/src/proxy.lisp
+++ b/src/proxy.lisp
@@ -29,7 +29,14 @@
   (:actual-type :pointer))
 
 
+#-(or libgit2-0.28 libgit2-0.27)
 (defcfun %git-proxy-options-init
+    %return-value
+  (options :pointer)
+  (version :uint))
+
+#+(or libgit2-0.28 libgit2-0.27)
+(defcfun ("git_proxy_init_options" %git-proxy-options-init)
     %return-value
   (options :pointer)
   (version :uint))

--- a/src/remote.lisp
+++ b/src/remote.lisp
@@ -208,7 +208,14 @@ foreign memory."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+#-(or libgit2-0.28 libgit2-0.27)
 (defcfun %git-fetch-options-init
+    %return-value
+  (options :pointer)
+  (version :uint))
+
+#+(or libgit2-0.28 libgit2-0.27)
+(defcfun ("git_fetch_init_options" %git-fetch-options-init)
     %return-value
   (options :pointer)
   (version :uint))

--- a/src/signature.lisp
+++ b/src/signature.lisp
@@ -73,7 +73,7 @@
            (setf offset (timezone-offset time))
            (setf sign (char-int (if (< offset 0) #\- #\+)))))
        (with-foreign-slots ((name email when) signature (:struct git-signature))
-         (setf name (getf value :name (getenv "USER")))
+         (setf name (getf value :name (default-name)))
          (setf email (getf value :email (default-email))))
        signature))
     (t
@@ -111,6 +111,10 @@ OFFSET."
 ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defun default-name ()
+  (or (getenv "USER") "cl-git"))
+
 (defun default-email ()
   (or (getenv "MAIL")
-      (concatenate 'string (getenv "USERNAME") "@" (machine-instance))))
+      (concatenate 'string (or (getenv "USERNAME") (default-name))
+                   "@" (machine-instance))))


### PR DESCRIPTION
fixes #41 

add support for old versions of libgit2 are now 0.27, 0.28, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5
