### PR TITLE
Changed path identifier of libgit2 dylib on darwin.

### DIFF
--- a/src/libgit2-lib.lisp
+++ b/src/libgit2-lib.lisp
@@ -24,7 +24,7 @@
 (define-foreign-library libgit2
   (:linux "libgit2.so")
   (:windows "libgit2.dll")
-  (:darwin "libgit2.0.dylib")
+  (:darwin "libgit2.dylib")
   (:default "libgit2"))
 
 (unless (foreign-library-loaded-p 'libgit2)


### PR DESCRIPTION
To make `cl-git` work on my macbook (m2), I need to change the name of the dylib `libgit2`, and added the following env variable.

```
export C_INCLUDE_PATH="/opt/homebrew/include"
```

Feel free to cancel this pull request. I made it anyways because it could be helpful for future mac users.